### PR TITLE
Use the plugin's name and not the parsed argument

### DIFF
--- a/src/main/java/com/rylinaux/plugman/util/PluginUtil.java
+++ b/src/main/java/com/rylinaux/plugman/util/PluginUtil.java
@@ -365,7 +365,7 @@ public class PluginUtil {
         target.onLoad();
         Bukkit.getPluginManager().enablePlugin(target);
 
-        return PlugMan.getInstance().getMessageFormatter().format("load.loaded", name);
+        return PlugMan.getInstance().getMessageFormatter().format("load.loaded", target.getName());
 
     }
 


### PR DESCRIPTION
Allows for cleaner messages.

**Issue Example:**
![screenshot_1](https://user-images.githubusercontent.com/1522389/27906105-50addd0c-6281-11e7-8e63-43bb23dfe838.png)
