### PR TITLE
Added Soft-/Dependencies to Info command output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/out/
 /.idea/
 /*.iml
 dependency-reduced-pom.xml

--- a/src/main/java/com/rylinaux/plugman/command/InfoCommand.java
+++ b/src/main/java/com/rylinaux/plugman/command/InfoCommand.java
@@ -36,6 +36,8 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
+import java.util.List;
+
 /**
  * Command that displays information on a plugin.
  *
@@ -111,11 +113,15 @@ public class InfoCommand extends AbstractCommand {
         String version = target.getDescription().getVersion();
         String authors = Joiner.on(", ").join(target.getDescription().getAuthors());
         String status = target.isEnabled() ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled";
+        List<String> dependList = target.getDescription().getDepend();
+        List<String> softdependList = target.getDescription().getSoftDepend();
 
         sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format("info.header", name));
         sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format(false, "info.version", version));
         sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format(false, "info.authors", authors));
         sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format(false, "info.status", status));
+        if (!dependList.isEmpty()) sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format(false, "info.depends", Joiner.on(", ").join(dependList)));
+        if (!softdependList.isEmpty()) sender.sendMessage(PlugMan.getInstance().getMessageFormatter().format(false, "info.softdepends", Joiner.on(", ").join(softdependList)));
 
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -60,6 +60,8 @@ info:
   version: '&7- Version: &a{0}'
   authors: '&7- Author(s): &a{0}'
   status: '&7- Status: {0}'
+  depends: '&7- Depends: {0}'
+  softdepends: '&7- SoftDepends: &a{0}'
 list:
   list: '&9Plugins ({0}): {1}'
 load:


### PR DESCRIPTION
- Dependencies and soft-dependencies, should they exist, are displayed in the Info command output. 
- Corresponding sections added to messages.yml as well.