### PR TITLE
Potential fix for tabcomplete permission issue

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ api-version: 1.13
 commands:
   plugman:
     description: Manage plugins.
+    permission: plugman.help
     usage: /plugman (help|dump)
            /plugman list [-v]
            /plugman check <plugin|all> [-f]


### PR DESCRIPTION
Should fix tabcomplete issue whereby a player without the permission to use /plugman can see the command in tabcomplete. Please test this before merging.